### PR TITLE
Responsive Mobile Menu

### DIFF
--- a/_includes/enroll.html
+++ b/_includes/enroll.html
@@ -1,4 +1,4 @@
-<div class="fixed bottom-10 md:right-5 z-2">
+<div id="enroll" class="fixed bottom-10 md:right-5 z-2">
   <div class="grid grid-rows md:grid-cols-2 place-content-end gap-y-10">
     <div>
       <a href="https://openspaces.platoniq.net/processes/prelanzamiento/f/445/" class="bg-white border-1 rounded-full text-2xl text-black px-6 py-3 font-medium">
@@ -12,4 +12,3 @@
     </div>
   </div>
 </div>
-

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -10,12 +10,26 @@
       {% endfor %}
     </div>
 
-    <div class="md:hidden">
+    <div id="mobile-menu-button" class="md:hidden">
       <button>
         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
           <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5" />
         </svg>
       </button>
     </div>
+    <div id="mobile-menu" class="hidden md:hidden bg-white w-full absolute top-[75px] left-0 shadow-lg">
+      <div class="flex flex-col items-center py-4">
+        {% for section in site.data.sections %}
+          <a class="border border-white w-3/4 text-center text-xl py-2 my-2 hover:border-black rounded-full box-border" href="{{ section.link }}">{{ section.name }}</a>
+        {% endfor %}
+      </div>
+    </div>
   </nav>
+  <script>
+    document.getElementById("mobile-menu-button").addEventListener("click", function() {
+      const mobileMenu = document.getElementById("mobile-menu");
+      mobileMenu.classList.toggle("hidden");
+      document.getElementById("enroll").classList.toggle("hidden");
+    });
+  </script>
 </header>

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -20,7 +20,7 @@
     <div id="mobile-menu" class="hidden md:hidden bg-white w-full absolute top-[75px] left-0 shadow-lg">
       <div class="flex flex-col items-center py-4">
         {% for section in site.data.sections %}
-          <a class="border border-white w-3/4 text-center text-xl py-2 my-2 hover:border-black rounded-full box-border" href="{{ section.link }}">{{ section.name }}</a>
+          <a class="border border-white w-3/4 text-center text-2xl my-2 hover:border-black rounded-full box-border" href="{{ section.link }}">{{ section.name }}</a>
         {% endfor %}
       </div>
     </div>


### PR DESCRIPTION
<img width="380" alt="image" src="https://github.com/user-attachments/assets/a045854d-e590-4e10-82ec-2af12353eabd" />

<img width="383" alt="image" src="https://github.com/user-attachments/assets/d9942245-5bf8-4e80-8e26-d5d53f386dab" />

Notes:

- JS <script> might not be in the ideal location.
- I hid the sticky info about "enrolling" when displaying the mobile menu. It returns when the mobile menu is closed.